### PR TITLE
fix(ci): remove invalid mkdocs-serve from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pre-commit
 tox
 
 # Documentation development
-mkdocs-serve
+# Removed invalid package 'mkdocs-serve' (use `mkdocs serve` from mkdocs)
 mkdocs-macros-plugin
 
 # Code formatting and linting (dev versions)


### PR DESCRIPTION
Fix CI failure in 'ci-cd-pipeline' caused by pip error:

ERROR: Could not find a version that satisfies the requirement mkdocs-serve (from versions: none)

- Remove nonexistent package 'mkdocs-serve' from requirements-dev.txt
- Note: MkDocs already provides `mkdocs serve`; no separate package needed

This should allow the Install dependencies step to complete and unblock the rest of the pipeline.

Fixes #4